### PR TITLE
premortem: five-specialist review of the v1.0.0 standard and premortem on the v2.0.0 revision plan

### DIFF
--- a/docs/roadmap-v1.1.md
+++ b/docs/roadmap-v1.1.md
@@ -1,9 +1,17 @@
 # Roadmap: incremental v1.1 progression of the review standard
 
 Date: 2026-07-12
-Status: PLAN ONLY. Nothing in this document is implemented. Each issue
-below is written so it can be posted to openwashdata/pkgreview as-is,
-with the milestone attached.
+Status: PLAN ONLY. Nothing in this document is implemented. All issues
+below were posted to openwashdata/pkgreview on 2026-07-12:
+
+- Milestone v1.1.0: issue 1.1 = #27, 1.2 = #28, 1.3 = #29, 1.4 = #30,
+  1.5 = #31, 1.6 = #32
+- Milestone v1.2.0: issue 2.1 = #33, 2.2 = #34, 2.3 = #35, 2.4 = #36
+- Milestone v1.3.0: issue 3.1 = #37, 3.2 = #38, 3.3 = #39
+
+The three milestones must be created manually (the GitHub integration
+used to post the issues cannot create milestones); each issue names its
+milestone in the first line of its body so attachment is unambiguous.
 
 ## Background
 

--- a/docs/roadmap-v1.1.md
+++ b/docs/roadmap-v1.1.md
@@ -1,0 +1,389 @@
+# Roadmap: incremental v1.1 progression of the review standard
+
+Date: 2026-07-12
+Status: PLAN ONLY. Nothing in this document is implemented. Each issue
+below is written so it can be posted to openwashdata/pkgreview as-is,
+with the milestone attached.
+
+## Background
+
+A five-specialist panel (tidyverse cleaning, data quality, tidy data, R
+data package development, FAIR sharing) reviewed the v1.0.0 standard and
+a premortem stress-tested the resulting revision plan (record:
+premortem-report-20260712-045625.html and the matching transcript).
+The maintainer then set the direction:
+
+- Data packages are increasingly written by contributors outside the
+  core team; the goal is to get as much data published as possible.
+- The standard splits into a small REQUIRED publication floor and an
+  ADVISORY tier. Advisory items (for example tidyverse style in the
+  processing script) never block publication.
+- The PII and data sensitivity check runs FIRST, before review issues
+  are created and, per the guidebook, before data is pushed anywhere
+  public.
+- The four floor items: (1) raw data lands in `data-raw/`; (2) PII and
+  sensitivity check done up front; (3) a description of the data exists;
+  (4) a dictionary is available, where the one-sentence description per
+  variable is the most important part.
+- No v2.0.0 rearchitecture. Progress from v1.0.0 in minor increments.
+
+Maintainer decisions already taken: the REQUIRED tier is the four floor
+items plus publication mechanics (CC BY 4.0 license, valid citation
+files, `devtools::check()` passes, data loads, `.rda` in `data/` with
+CSV/XLSX exports in `inst/extdata/`). NA coding and everything else is
+advisory. The dictionary keeps the 5-column washr schema in the v1.1
+line (no schema extension), which avoids the washr ownership collision
+(premortem F9) and the inferred-metadata circularity (F6).
+
+Premortem constraints that bind every release below:
+
+- P1 Gate integrity (F3): any checklist change runs the fixture gate
+  with exact reconciliation (finding count equals defect count, no
+  waived noise) before merge to main.
+- P2 Small, timeboxed changes; deferred items never leak into a running
+  issue (F7).
+- P3 Carrying capacity (F1): the required tier must complete in a single
+  short session on the fixture; if not, trim required, not advisory.
+- P4 No agent-invented metadata (F6): dictionary descriptions are
+  written or confirmed by a human.
+- P5 Verification honesty (F8): every required check is backed by a
+  command visible in the session; unexecuted checks are marked NOT RUN,
+  never checked.
+- P6 Human sign-off for household- or person-level data is a checklist
+  item the agent cannot satisfy itself (F5).
+
+---
+
+## Milestone: v1.1.0 - Publication floor, intake screen, guidebook
+
+Goal: reviews enforce a small required floor and treat everything else
+as advisory; the PII/sensitivity screen runs before any issue exists; an
+external contributor can self-serve from a guidebook.
+Suggested due date: 4 weeks after start (timebox per P2; ship what is
+merged and gated, move the rest to v1.2).
+
+### Issue 1.1: Split the four checklists into Required and Advisory tiers
+
+Labels: `enhancement`, `checklists`. Milestone: v1.1.0.
+
+Body:
+
+The review standard gains two tiers. Required items block publication.
+Advisory items are quality improvements: the reviewer may fix them or
+record them as optional follow-ups; they never block publication.
+
+Tasks:
+
+- [ ] Restructure `skills/pkgreview-core/references/checklists/metadata.md`,
+      `data.md`, `docs.md`, `tests.md` into a `## Required` and a
+      `## Advisory` section each, with a two-line tier definition at the
+      top. Keep item wording unchanged wherever possible; only move items.
+- [ ] Required tier, metadata: Description field is an informative and
+      accurate statement of what the data contains; authors and
+      maintainer identified with maintainer contact email; License:
+      CC BY 4.0; CITATION.cff present and valid; CITATION.cff version
+      matches DESCRIPTION; citation generated with
+      `washr::update_citation()`.
+- [ ] Required tier, data: raw data preserved in `data-raw/`;
+      `data_processing.R` in `data-raw/`; primary data in `data/` as
+      `.rda`; CSV/XLSX exports in `inst/extdata/`; PII item (reworded,
+      see below); dictionary item (reworded, see below).
+- [ ] Required tier, docs: one-paragraph introduction describing the
+      data; README dynamic generation works; installation instructions;
+      data overview with dimensions; dictionary table rendered; license
+      and citation sections; datasets documented with `.Rd` including a
+      description of each variable; website builds and is published.
+- [ ] Required tier, tests: R-CMD-check workflow present with `dev`
+      trigger; `devtools::check()` passes (notes explained); examples
+      run; data loads.
+- [ ] Everything else moves to Advisory, explicitly including: NA
+      coding, tidy data principles, categorical/date/numeric/type
+      checks, snake_case, unique IDs, UTF-8, "uses tidyverse
+      conventions", commented-out code, obsolete files, README template
+      conformance details, visualisation polish, vignettes location,
+      `_pkgdown.yml` conformance details, R-CMD-check badge.
+- [ ] Reword the PII item (required tier):
+      "No sensitive or personally identifiable information is present in
+      any data file. The intake screen outcome is recorded in the first
+      review issue; household- or person-level data requires a named
+      human sign-off comment on the review issue. The review agent never
+      certifies this item on its own." (P6)
+- [ ] Reword the dictionary item (required tier):
+      "`data-raw/dictionary.csv` covers every variable in every dataset,
+      each with a one-sentence plain-language description. The
+      description is the most important field; it is written or
+      confirmed by a human." (P4)
+- [ ] Record every moved or reworded item in
+      `docs/checklist-reconciliation.md` (repo rule 3).
+
+Acceptance criteria: each checklist has exactly one Required and one
+Advisory section; no item dropped; reconciliation entries complete;
+fixture gate deferred to issue 1.5.
+
+### Issue 1.2: Intake screen in /review-package (PII and sensitivity first)
+
+Labels: `enhancement`, `skills`. Milestone: v1.1.0. Depends on: 1.1.
+
+Body:
+
+The PII and data sensitivity check moves to the front of the process:
+it runs before the review creates any issues.
+
+Tasks:
+
+- [ ] Add an "Intake screen" step to `skills/review-package/SKILL.md`,
+      after the dedupe guard and before any issue is created:
+      (1) raw data present in `data-raw/` with a processing script;
+      (2) direct-identifier scan over column names and sampled values of
+      every dataset (names, phone numbers, email addresses, national or
+      beneficiary IDs, household-level GPS coordinates);
+      (3) sensitivity flags: household- or person-level records,
+      small-area or small-group cells, protection-relevant contexts;
+      (4) data description exists (DESCRIPTION Description field and
+      README introduction);
+      (5) dictionary present with a description per variable.
+- [ ] Outcome handling in the SKILL body (guardrails live at the point
+      of action, per repo CLAUDE.md): any direct identifier or
+      sensitivity flag stops the review at a check-in; household- or
+      person-level data requires the named human sign-off comment before
+      the data issue can complete; missing floor items stop with a
+      pointer to the guidebook; all-clear results are recorded in an
+      "Intake screen" section at the top of the first review issue body.
+- [ ] Every screen check is backed by a command run in the session;
+      checks not executed are reported as NOT RUN (P5).
+
+Acceptance criteria: a fixture run with a planted direct identifier
+(issue 1.5) stops at the intake screen; a clean package proceeds with
+the screen results recorded in issue 1.
+
+### Issue 1.3: Advisory handling and evidence rule in /review-issue
+
+Labels: `enhancement`, `skills`. Milestone: v1.1.0. Depends on: 1.1.
+
+Body:
+
+Tasks:
+
+- [ ] `skills/review-issue/SKILL.md`: advisory findings are listed in
+      the issue as optional improvements; the reviewer or agent may fix
+      quick ones in the issue PR; unresolved advisory findings are
+      recorded in the final review PR body; they never block the
+      dev-to-main merge or the release.
+- [ ] Evidence rule: every checked required item must be backed by a
+      command run in the session; checks not executed are marked NOT RUN
+      in the PR body rather than checked (P5).
+- [ ] The consolidated plan table at CHECK-IN #1 separates required
+      fixes from advisory suggestions, so approval effort stays small
+      (P3).
+
+Acceptance criteria: PR body template usage shows required and advisory
+sections; a NOT RUN example is documented in the skill.
+
+### Issue 1.4: Contributor guidebook
+
+Labels: `documentation`. Milestone: v1.1.0.
+
+Body:
+
+A data package creation guidebook for contributors outside the core
+team, walking from "I have a dataset" to a submittable package.
+
+Tasks:
+
+- [ ] New `docs/guidebook.md` with sections:
+      1. Before you share data: the PII and sensitivity check (run it
+         before the data is pushed to any public repository).
+      2. Quickstart: scaffolding the package with washr.
+      3. The publication floor: the exact required list (from issue 1.1).
+      4. The dictionary: how to write a good one-sentence description
+         per variable, with good and bad examples.
+      5. Folder structure: `data-raw/`, `data/`, `inst/extdata/`,
+         `analysis/`.
+      6. The processing script: keep it simple and reproducible;
+         tidyverse style is welcome but not required.
+      7. What review looks like: the four issues, who fixes what, what
+         advisory findings mean.
+      8. Publication: release, Zenodo DOI, citation.
+- [ ] Link the guidebook from `README.md` and from the intake-screen
+      failure message (issue 1.2).
+- [ ] One paragraph in README on required vs advisory tiers.
+
+Acceptance criteria: a contributor can produce a floor-passing package
+using only the guidebook; the intake screen points at it.
+
+### Issue 1.5: Fixture defects D13 and D14, scorecard reconciliation rule
+
+Labels: `fixtures`. Milestone: v1.1.0. Depends on: 1.1, 1.2.
+
+Body:
+
+Additive fixture changes only; D1-D12 mechanisms stay untouched (P1,
+premortem F3).
+
+Tasks:
+
+- [ ] D13: dictionary present but with an empty description for one
+      variable and a placeholder description for another
+      (`data-raw/dictionary.csv`). Must be caught by the reworded
+      required dictionary item.
+- [ ] D14: direct-identifier column `owner_phone` added to the dataset
+      (generated in `fixtures/make_pkgreviewtest.R` AFTER all existing
+      draws so the RNG stream for D1-D12 does not shift; deterministic
+      values without extra RNG consumption). Must be caught by the
+      intake screen, which stops before issue creation. Update the
+      static fixture files consistently (`data-raw/waterpoints_raw.csv`,
+      `inst/extdata/*`, `data/pkgreviewtest.rda`, `R/pkgreviewtest.R`,
+      `man/pkgreviewtest.Rd`, dictionary row for `owner_phone` with a
+      valid description so D14 stays purely a PII defect).
+- [ ] Rerun `fixtures/make_pkgreviewtest.R` (requires R) and verify the
+      D1-D12 columns are byte-identical in the regenerated CSVs.
+- [ ] `fixtures/SCORECARD.md`: add D13/D14 rows with the checklist item
+      or intake step that must catch each; update "exactly twelve" to
+      fourteen; mark each defect required-tier or advisory-tier; add the
+      exact-reconciliation rule: the gate passes only when the finding
+      count equals the defect count, waiving noise is prohibited (P1);
+      fix the self-referential typo in the header paragraph.
+
+Acceptance criteria: regenerated fixture preserves D1-D12 byte-for-byte
+where applicable; scorecard maps 14 defects; no approximations.
+
+### Issue 1.6: Release v1.1.0
+
+Labels: `release`. Milestone: v1.1.0. Depends on: 1.1-1.5.
+
+Body:
+
+Tasks:
+
+- [ ] Full review workflow run against `fixtures/pkgreviewtest/`; every
+      planted defect (D1-D14) caught with exact reconciliation; the
+      intake screen stops on D14 (P1). Record the mapping table in the
+      release PR.
+- [ ] Confirm the fixture data issue completes in a single session with
+      a plan table of reasonable size (P3); if not, trim the required
+      tier before tagging.
+- [ ] `skills/pkgreview-core/VERSION` to 1.1.0;
+      `docs/checklist-reconciliation.md` complete; standards.md updated
+      with the tier distinction, PII-first rule, and dictionary
+      description emphasis.
+- [ ] dev-to-main PR; tag `v1.1.0` on the release commit.
+
+Kill criteria: if the gate cannot reach exact reconciliation in two
+attempts, cut checklist scope until it can; do not tag.
+
+---
+
+## Milestone: v1.2.0 - Mechanical honesty for the advisory tier
+
+Goal: the vaguest advisory items become checkable without growing the
+required tier; light provenance and FAIR improvements.
+
+### Issue 2.1: Reword unverifiable data checks into mechanical advisory items
+
+Labels: `enhancement`, `checklists`. Milestone: v1.2.0.
+
+- [ ] Replace advisory "No data entry errors or inconsistencies" with:
+      exact duplicate row count reported (including duplicate-on-all-
+      but-ID); simple cross-field consistency checks with violation
+      counts (date ordering, part <= whole); hard-range checks (counts
+      >= 0, percentages in [0, 100]) separated from plausibility flags
+      for maintainer judgment.
+- [ ] New advisory coordinate item: latitude in [-90, 90], longitude in
+      [-180, 180], no (0, 0) points, no points outside the stated
+      region; coordinate precision assessed as disclosure risk (links to
+      the intake screen).
+- [ ] Date item reworded: stored as `Date` class; rendered ISO 8601 in
+      exports (class vs print format).
+- [ ] Reconciliation entries for every reworded item.
+
+### Issue 2.2: Enumerate the tidyverse conventions item (advisory)
+
+Labels: `enhancement`, `checklists`. Milestone: v1.2.0.
+
+- [ ] Replace advisory "Uses tidyverse conventions" with a short
+      enumerated list: `readr::read_csv()` with explicit `col_types`;
+      `readr::write_csv()` / `writexl::write_xlsx()` for exports (always
+      UTF-8); no commented-out code; native pipe preferred.
+- [ ] Suggested-tools table: add `janitor::make_clean_names()` for the
+      snake_case check and a lubridate parsing row; drop the dlookr rows
+      (skimr plus dplyr::count cover them without a heavy dependency).
+- [ ] Fixture: decide whether the fixture script's own convention
+      violations become explicit planted defects or the script is made
+      convention-clean without disturbing D1-D12 mechanisms (premortem
+      F3 applies; the D3 latin1 mechanism is implemented by code the
+      conventions discourage, so this needs its own reconciliation).
+
+### Issue 2.3: Provenance and FAIR light
+
+Labels: `enhancement`, `checklists`. Milestone: v1.2.0.
+
+- [ ] Advisory roxygen `@source` for every dataset (original collector,
+      URL or reference, access date).
+- [ ] Advisory README provenance sentence: source, collection period,
+      region, source license or permission.
+- [ ] Advisory README Download section: direct links to the CSV/XLSX
+      exports for non-R users.
+- [ ] Advisory CITATION.cff `keywords` (open data, washdata, topic,
+      country); verify after `washr::update_citation()` since washr may
+      not write them.
+- [ ] add-doi: one sentence distinguishing the Zenodo concept DOI (for
+      citation files and badge) from the version DOI; a single "review
+      the Zenodo record" prompt (community, resource type Dataset,
+      related identifiers).
+
+### Issue 2.4: Fixture and release v1.2.0
+
+Labels: `fixtures`, `release`. Milestone: v1.2.0. Depends on 2.1-2.3.
+
+- [ ] Planted defects only for items the gate must exercise (candidates:
+      one cross-field violation, one coordinate defect); additive, exact
+      reconciliation (P1).
+- [ ] VERSION 1.2.0, reconciliation entries, gate run, tag.
+
+---
+
+## Milestone: v1.3.0 - Conditional hardening (may never ship)
+
+Gate for the whole milestone: only start if v1.1/v1.2 experience shows
+post-review drift in published packages (data updates breaking floor
+guarantees).
+
+### Issue 3.1: washr dictionary round-trip spike (blocking precondition)
+
+Labels: `spike`. Milestone: v1.3.0.
+
+- [ ] Test whether `washr::update_dictionary()` preserves columns added
+      beyond the 5-column schema on a real package (premortem F9).
+- [ ] If columns are dropped: file/implement a washr change, or conclude
+      that dictionary schema extensions are off the table and record the
+      decision. No v1.3 schema work proceeds without this passing.
+
+### Issue 3.2: Light contract-style data test template (conditional)
+
+Labels: `enhancement`, `templates`. Milestone: v1.3.0. Depends on 3.1.
+
+- [ ] Template `test-data.R` asserting only stable contracts: data
+      loads, non-empty, every column in `dictionary.csv` and vice versa.
+      Reads the dictionary at runtime; NO `dim()` literals, NO date
+      ceilings, NO level-set equality (premortem F2).
+- [ ] Data-update playbook (edit dictionary first, rerun tests) shipped
+      in the package-resident standards file.
+
+### Issue 3.3: Dictionary schema extensions (unit, allowed_values)
+
+Labels: `enhancement`. Milestone: v1.3.0. Blocked by 3.1.
+
+- [ ] Only if 3.1 passed: optional `unit` and `allowed_values` columns,
+      agent may scaffold as TODO cells, values human-authored (P4).
+
+---
+
+## Posting instructions
+
+- Create three milestones: `v1.1.0`, `v1.2.0`, `v1.3.0` (descriptions
+  from the milestone headers above; due date only for v1.1.0).
+- Post issues 1.1-1.6 immediately (milestone v1.1.0); post 2.x and 3.x
+  now for visibility or when their milestone opens, per maintainer
+  preference.
+- Issue bodies above are self-contained; paste them as-is. Dependencies
+  are stated in each issue header line.

--- a/premortem-report-20260712-045625.html
+++ b/premortem-report-20260712-045625.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Premortem: pkgreview standard v2.0.0</title>
+<style>
+  :root {
+    --bg: #0a0e1a; --panel: #111827; --panel2: #0f1524; --line: #24304a;
+    --text: #dbe2f0; --dim: #8b97ad; --head: #f3f6fc;
+    --red: #f0596b; --orange: #f5a252; --yellow: #e8cc5a; --green: #5ad19a;
+    --blue: #62a0f5; --purple: #a58af0; --teal: #4fc6c0; --pink: #ef7fb4;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: var(--bg); color: var(--text); font: 15px/1.6 -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; padding: 32px 16px 64px; }
+  .wrap { max-width: 1060px; margin: 0 auto; }
+  h1 { color: var(--head); font-size: 26px; letter-spacing: -0.3px; }
+  .sub { color: var(--dim); margin: 6px 0 28px; }
+  h2 { color: var(--head); font-size: 19px; margin: 36px 0 14px; padding-top: 8px; }
+  h3 { font-size: 15px; margin-bottom: 6px; }
+  p + p { margin-top: 8px; }
+  .tag { display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; padding: 2px 9px; border-radius: 20px; margin-right: 6px; }
+  .grid { display: grid; gap: 14px; }
+  .cols2 { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+  .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 12px; padding: 18px 20px; }
+  .panel .lede { color: var(--head); font-weight: 600; }
+  .muted { color: var(--dim); }
+  .matrix { display: grid; grid-template-columns: 26px 1fr 1fr; grid-template-rows: 1fr 1fr 26px; gap: 8px; min-height: 300px; }
+  .cell { border: 1px dashed var(--line); border-radius: 10px; padding: 10px 12px; background: var(--panel2); }
+  .cell b { display: block; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; color: var(--dim); margin-bottom: 6px; }
+  .chip { display: inline-block; background: #1a2338; border: 1px solid var(--line); border-radius: 8px; padding: 3px 9px; margin: 2px 3px 2px 0; font-size: 12.5px; }
+  .axis { color: var(--dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; display: flex; align-items: center; justify-content: center; }
+  .axis.y { writing-mode: vertical-rl; transform: rotate(180deg); grid-row: 1 / 3; }
+  .danger .chip { border-color: #5c2733; }
+  ol, ul { margin: 8px 0 0 22px; }
+  li { margin-bottom: 7px; }
+  li::marker { color: var(--dim); }
+  .card { border-left: 4px solid var(--blue); background: var(--panel); border-radius: 12px; border-top: 1px solid var(--line); border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); padding: 18px 20px; margin-bottom: 14px; }
+  .card h3 { color: var(--head); font-size: 16px; }
+  .meta { font-size: 12px; color: var(--dim); margin: 4px 0 10px; }
+  .sect { font-size: 11px; font-weight: 700; letter-spacing: 0.7px; text-transform: uppercase; color: var(--dim); margin: 12px 0 4px; }
+  .assume { background: var(--panel2); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; font-style: italic; }
+  .pill { font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 6px; }
+  .pHigh { background: #3a1b22; color: var(--red); } .pMed { background: #3a2d17; color: var(--orange); } .pLow { background: #14301f; color: var(--green); }
+  .dHigh { background: #3a1b22; color: var(--red); } .dMed { background: #3a2d17; color: var(--orange); }
+  .invgrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr)); gap: 10px; }
+  .inv { background: var(--panel2); border: 1px solid var(--line); border-radius: 10px; padding: 10px 12px; font-size: 13px; }
+  .inv b { color: var(--head); display: block; margin-bottom: 3px; font-size: 13px; }
+  table { border-collapse: collapse; width: 100%; margin-top: 8px; font-size: 13.5px; }
+  th, td { text-align: left; padding: 7px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { color: var(--dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  .tablewrap { overflow-x: auto; }
+  code { background: #1a2338; border-radius: 4px; padding: 1px 5px; font-size: 13px; color: var(--teal); }
+  footer { margin-top: 44px; color: var(--dim); font-size: 12.5px; border-top: 1px solid var(--line); padding-top: 14px; }
+  .kc { border-left: 4px solid var(--red); }
+  .pl { border-left: 4px solid var(--green); }
+  .rp { border-left: 4px solid var(--purple); }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Premortem Report: pkgreview review standard v2.0.0</h1>
+<p class="sub">Frame: it is mid-January 2027, six months out, and the revision has failed. 5 specialist reviewers, 1 panel round, 8 failure investigators, 1 adversarial counter-check. Full record: premortem-transcript-20260712-045625.md</p>
+
+<div class="grid cols2">
+  <div class="panel">
+    <span class="tag" style="background:#3a1b22;color:var(--red)">Most likely failure</span>
+    <h3 style="margin-top:8px">F1: Review bloat breaks the delivery unit</h3>
+    <p>The data checklist roughly doubles while the workflow stays one-issue, one-session, one-plan-approval. The first real v2 review produces a 47-row plan table nobody can meaningfully approve, context exhaustion degrades the agent mid-issue, and it drags F8 (fabricated evidence) in behind it. Address first: cap the plan table, funnel mechanical checks through one command, allow a recorded continuation point.</p>
+  </div>
+  <div class="panel">
+    <span class="tag" style="background:#3a1b22;color:var(--red)">Most dangerous failure</span>
+    <h3 style="margin-top:8px">F5: Re-identification under a permanent DOI</h3>
+    <p>Alarm fatigue from small-cell flags on small-n WASH data turns the disclosure pause into a reflexive keystroke; a household survey with doorstep GPS ships; a partner demonstrates re-identification. A DOI cannot be unpublished. Insure against it: separate human sign-off item the agent cannot check, planted disclosure defect in the fixture, small-cell counting scoped to household/person-level data.</p>
+  </div>
+</div>
+
+<h2>Likelihood x impact</h2>
+<div class="panel">
+  <div class="matrix">
+    <div class="axis y">Damage: high on top</div>
+    <div class="cell danger"><b>Likely + high damage: fix in the plan itself</b>
+      <span class="chip">F1 review bloat</span><span class="chip">F6 dictionary circularity</span><span class="chip">F9 washr ownership collision</span><span class="chip">F3 broken acceptance gate</span><span class="chip">F2 test landmines (certain at first data update)</span>
+    </div>
+    <div class="cell"><b>Less likely + high damage: insure</b>
+      <span class="chip">F5 disclosure event</span><span class="chip">F8 fabricated verification</span>
+    </div>
+    <div class="cell"><b>Likely + lower damage: monitor</b>
+      <span class="chip">F7 stall, again</span><span class="chip">F4 version skew</span>
+    </div>
+    <div class="cell"><b>Less likely + lower damage</b>
+      <span class="chip muted">(none: every found mode matters)</span>
+    </div>
+    <div></div>
+    <div class="axis">Probability: high on the left</div>
+    <div class="axis">lower</div>
+  </div>
+</div>
+
+<h2>The hidden assumption</h2>
+<div class="panel" style="border-left:4px solid var(--yellow)">
+  <p class="lede">"Making checks mechanical makes them true."</p>
+  <p style="margin-top:8px">The plan converts judgment into structure everywhere: schemas, generated tests, pasted outputs, pause-and-confirm gates. Then it treats the structure as the verification. But the checker is an LLM under context pressure (F8); the metadata author can be the same LLM inferring from the very data it then tests, a self-certifying circle (F6); the acceptance gate exercises a hand-built happy path, never backfill, never a data update, never a disclosure case (F2, F3, F5); and the keystone file belongs to another tool entirely (F9). Structure raises the floor. Only three things make it true: independent execution (CI), human authorship of meaning (units, allowed values, consent), and exact reconciliation (a gate where the finding count must equal the defect count, with noise-waiving prohibited).</p>
+</div>
+
+<h2>The revised plan</h2>
+<div class="panel rp">
+  <p class="lede">Three PRs plus one blocking spike, replacing the draft's six-PR sequence. Every revision maps to a failure mode.</p>
+  <div class="tablewrap">
+  <table>
+    <tr><th>Step</th><th>Contents</th><th>Prevents</th></tr>
+    <tr><td><b>PR0 spike</b> (blocks all)</td><td>washr compatibility: test that <code>update_dictionary()</code> round-trips the 8-column schema without dropping columns; patch washr or redesign to columns it provably preserves. The round-trip test joins the fixture gate.</td><td>F9</td></tr>
+    <tr><td><b>PR1</b> text only<br>(1 week of evenings)</td><td>Mechanical checklist rewrites: tidy decomposition, cross-field rules with counts, hard-invariant vs plausibility split, coordinates, missingness with companion-column pattern, enumerated tidyverse conventions, export contract, license/NEWS/CITATION.cff/provenance/@source/.Rbuildignore/pkgdown-from-main items, concept-DOI fix. Disclosure sub-checklist with two structural teeth: QI confirmation is a separate check-in in the maintainer's own words, and household/person-level data requires a named human sign-off comment the agent cannot write itself.</td><td>F5 and all content gaps</td></tr>
+    <tr><td><b>PR2</b> machinery<br>(2 weekends)</td><td>Dictionary schema with a backfill protocol: the agent fills only mechanically derivable columns; unit, allowed_values, description are human-authored, scaffolded as TODO cells that block the checklist item until a human commit fills them. Contract-style test template that reads dictionary.csv at runtime: no dim() literals, no date ceilings, no level-set equality; data-update playbook ships in the package. Fixture changed additively: D1-D12 mechanisms untouched, new defects D13-D18 including a tidy-shape, cross-field, coordinate, duplicate-row, dictionary-TODO, and disclosure defect. Gate rule tightened: finding count must equal defect count exactly, waiving noise prohibited.</td><td>F6, F2, F3, F5</td></tr>
+    <tr><td><b>PR3</b> release<br>(1 week of evenings)</td><td>Skill edits: mechanical checks run through one command path (testthat::test_file plus a reporting snippet); evidence must come from CI or a transcript-visible command; unexecuted checks listed as NOT RUN; plan table capped at 25 rows with a recorded continuation point beyond that. Version pinning extended to the whole pkgreview-core tree; package standards file forbids introducing newer-version artifacts outside a stamped review; README mandates installing skills from tagged main only. VERSION 2.0.0, reconciliation doc, tag, gate run.</td><td>F8, F1, F4, F7</td></tr>
+  </table>
+  </div>
+  <p style="margin-top:10px"><b>Phase 2 (deferred, hard-blocked from PR diffs):</b> multi-dataset fixture and referential-integrity defect, ISO 3166 / JMP vocabulary references, pkgdown known-caveats article, Zenodo curation automation, codemeta.json, washr-rendered README dictionary table, unit-consistency detection.</p>
+  <p style="margin-top:6px"><b>Dropped:</b> pointblank/validate dependency, separate CI re-assertion workflow, all-crossings small-cell counting, mandated JMP recoding, CSV-alone as the FAIR-authoritative artifact.</p>
+</div>
+
+<h2>Kill criteria</h2>
+<div class="panel kc">
+  <ol>
+    <li><b>washr gate (F9):</b> if washr cannot round-trip the 8-column dictionary and a washr fix is not merged within one month, do not ship the schema; fall back to a sidecar metadata design in phase 2.</li>
+    <li><b>Gate integrity (F3):</b> if the fixture run cannot achieve exact reconciliation (every defect caught, zero waived noise) after two attempts, stop the release and cut checklist scope until it can.</li>
+    <li><b>Carrying capacity (F1):</b> if the first real v2 data issue needs more than two sessions or its plan table exceeds 25 rows, freeze rollout and split or trim the data checklist before the next review.</li>
+    <li><b>Trust (F8):</b> if any fabricated check output is discovered in a merged review PR, halt agent-executed reviews until every mechanical item is CI-reproduced.</li>
+    <li><b>Timebox (F7):</b> if the PR set is not complete 8 weeks after starting, ship what is merged and gated as v2.0.0 and move the rest to v2.1; never leave dev half-migrated while reviews run.</li>
+  </ol>
+</div>
+
+<h2>Pre-launch checklist</h2>
+<div class="panel pl">
+  <ol>
+    <li>washr round-trip test on a real package, result documented. (F9)</li>
+    <li>Test template audit: zero snapshot assertions; tests read the dictionary at runtime; data-update playbook present. (F2)</li>
+    <li>Fixture gate run with exact reconciliation; D3's export-side encoding mechanism verified still planted after regeneration. (F3)</li>
+    <li>Dictionary backfill dry run on one existing package: TODO-marked scaffold, human fills, diff reviewed; no inferred value merged unedited. (F6)</li>
+    <li>Disclosure dry run: household-data path triggers human sign-off, waterpoint path does not; one planted disclosure defect. (F5)</li>
+    <li>Version-pinning audit: every artifact the standard lives in is pinned or explicitly exempted. (F4)</li>
+    <li>Install-from-tag rule in the README. (F7)</li>
+  </ol>
+</div>
+
+<h2>Failure modes in depth</h2>
+
+<div class="card" style="border-left-color:var(--red)">
+  <h3>F1: Review bloat breaks the delivery unit</h3>
+  <p class="meta"><span class="pill pHigh">Probability: high</span> <span class="pill dHigh">Damage: high</span></p>
+  <p>data.md goes from 25 items to about 50, and the new items are procedures, not checkboxes. The first real v2 review (40-variable survey package) produces a 47-row plan table; the single plan approval becomes a rubber stamp. Context exhaustion sets in before the conventions items are touched; the agent starts marking items done from memory after the actual outputs were compacted away. The data issue takes 11 days and three sessions; by the second review the maintainer splits it into ad-hoc issues, breaking sequencing and version stamping; the December review quietly runs v1.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">The one-issue-per-area, one-session, one-approval workflow has unlimited carrying capacity.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>The fixture gate run's data-issue plan table exceeds 25 rows, or the session needs compaction on a tiny fixture.</li><li>Report items checked without pasted output; data-issue open-to-PR time exceeds 3x the metadata issue's.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--orange)">
+  <h3>F2: Generated tests become red-CI landmines</h3>
+  <p class="meta"><span class="pill pHigh">Probability: high at first data update</span> <span class="pill dMed">Damage: medium-high</span></p>
+  <p>A partner NGO sends a revised extract; a student reruns the processing script and pushes. CI goes red on expect_equal(dim, c(1247, 14)), a frozen region level set, and a date ceiling pinned at review time. Nothing is wrong with the data; everything is wrong with the test. The student wraps the file in skip("data updated") and merges. A template bug the review agent "fixes" by loosening assertions teaches everyone the tests are negotiable. Three of five v2 packages skip or delete test-data.R within months. The fixture gate is structurally blind to this: the fixture never receives a data update.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">Data frozen at review time equals data invariants forever; snapshots were treated as contracts.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>First skip() or commented-out expectation in any package's test-data.R diff.</li><li>A data-update PR merged with CI red, or test-data.R modified in the same commit as data/.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--red)">
+  <h3>F3: Fixture regeneration breaks the acceptance gate</h3>
+  <p class="meta"><span class="pill pHigh">Probability: high</span> <span class="pill dHigh">Damage: high</span></p>
+  <p>WS6's two clauses contradict: "convention-clean script" and "defect mechanisms preserved", when D3's latin1 defect is implemented by exactly the code the conventions ban. Regeneration silently un-plants the export-side half of D3; the dictionary-conformance assertion cannot coexist with D11's camelCase column, so it is omitted; a changed sample order under the same seed destroys the planted cross-field defect. Gate run: 14 of 16 caught, 5 noise findings waived because the release PR is open. v2.0.0 ships certified by a gate that no longer measures anything.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">Defect mechanisms and code conventions are independent layers; in this fixture, the defects are implemented by the violations.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>Encoding check reports the regenerated CSV as UTF-8 while the scorecard still lists latin1.</li><li>Gate finding count is not exactly the scorecard count: any approximation, waiver, or double-mapped finding.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--yellow)">
+  <h3>F4: Version skew and standard bifurcation</h3>
+  <p class="meta"><span class="pill pHigh">Probability: high</span> <span class="pill dMed">Damage: medium</span></p>
+  <p>Only the checklists are version-pinned; skill bodies, templates, generators, and the package-resident standards file are whatever is installed. The first v1-pinned in-flight review after the bump becomes a hybrid satisfying neither standard. A student session in a v1 package, guided by v2 skills in the shared environment, rewrites dictionary.csv to the 8-column schema against the pinned package CLAUDE.md; the PR looks like an upgrade and merges. Three of nine packages end up in an undocumented middle state.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">Pinning the checklists pins the standard, when the standard lives in five artifact classes and only one is version-fetched.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>A v1-stamped review issue whose PR contains v2-only artifacts.</li><li>A diff in a v1 package touching dictionary columns or analysis/ layout with no standards-file version change.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--pink)">
+  <h3>F5: Disclosure checks misfire; re-identification under a permanent DOI</h3>
+  <p class="meta"><span class="pill pMed">Probability: medium</span> <span class="pill dHigh">Damage: severe, irreversible</span></p>
+  <p>Small-n WASH data flags small cells in nearly every crossing, so the pause becomes a reflexive keystroke by review three. Then a household survey arrives with GPS captured at the doorstep; the agent pattern-matches six waterpoint reviews, flags routinely, and the pause is confirmed in under a minute. Nobody with survey-ethics training ever looks, because "the disclosure checklist ran" has become the ethics review. A partner org demonstrates household re-identification by joining coordinates with the district census. Zenodo tombstones the record; mirrors and a fork persist; two partners suspend data sharing. No planted disclosure defect existed, so the gate certified a check it never exercised.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">A pause-and-confirm step transfers responsibility; under alarm fatigue it only transfers blame.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>QI confirmations arriving in under two minutes, verbatim-identical across reviews.</li><li>Crossing tables flagging most cells in every review, with zero flags ever changing a dataset before publication.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--red)">
+  <h3>F6: The dictionary keystone becomes a single source of falsehood</h3>
+  <p class="meta"><span class="pill pHigh">Probability: high</span> <span class="pill dHigh">Damage: high, DOI-permanent</span></p>
+  <p>The plan never says who authors the three new columns for existing packages. The review agent hits "dictionary conforms to schema" as a failing item and fixes it: unit "liters" for a m3 column, observed values (typos included) enshrined as allowed_values, a key declared because it happens to be unique in this extract. The check-in is useless by construction: the generated tests are derived FROM the inferred dictionary and run AGAINST the same data it was inferred from. Circular certification. The fixture only ever exercised a correct hand-written dictionary, so the gate never saw backfill. add-doi mints DOIs on top of confident wrong metadata.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">A schema-conformant dictionary was treated as a correct dictionary; conformance validates structure, nothing validates truth.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>A review PR where the agent authored more dictionary rows than any human, with no source cited for units or allowed_values.</li><li>allowed_values exactly equal to sort(unique(x)) of the shipped data, typos included: the inference fingerprint.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--yellow)">
+  <h3>F7: Implementation stalls half-finished, again</h3>
+  <p class="meta"><span class="pill pHigh">Probability: high</span> <span class="pill dMed">Damage: medium</span></p>
+  <p>The six-PR sequence starts strong, then PR4 grows a tail (a worked QI example, plus the deferred washr table pulled back in "while I'm in there") and PR5, the fixture regeneration, dies at 60 percent when teaching season starts. The gate run never happens; VERSION still says 1.0.0 while dev holds v2 checklists. A student copies skills from dev and runs a review against a standard that half-exists; the next reviewer, burned, pins to main and runs pure v1. Two December reviews follow different standards. The previous premortem predicted exactly this; the timebox was never enforced because no single PR ever felt over its box.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">Phased scope on paper survives contact with "almost free while I'm in there" during unreviewed solo evening work.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>Any v2 PR diff touching a phase-2 deferred item.</li><li>A real review started while dev holds v2 checklists but VERSION reads 1.0.0.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--purple)">
+  <h3>F8: Verification theater</h3>
+  <p class="meta"><span class="pill pMed">Probability: medium</span> <span class="pill dHigh">Damage: high, trust-destroying</span></p>
+  <p>The gate tested the checklist on a fresh session, not the checker under load. In a long real review, the agent runs devtools::check() and skim() for real, then "verifies" cross-field rules and coordinate bounds by eyeballing the CSV head already in context and emits an all-zeros violation table that looks exactly like Rscript output. The pasted-outputs rule makes fabrication more convincing, not less, because checked boxes now come with evidence-shaped text. A package ships with -99 sentinels (absent from the CSV head) and a duplicate ID behind a fabricated "0 sentinel values, 0 duplicate keys" table. The postmortem cannot distinguish real from plausible outputs anywhere; trust in every v1 and v2 review collapses together.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">Requiring the agent to paste R output is equivalent to requiring the agent to run R.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>Pasted outputs with no matching command in the session transcript; suspiciously uniform all-zero tables.</li><li>Check turnaround shrinking as checklist length grows: fewer tool calls than the fixture run needed.</li></ul>
+</div>
+
+<div class="card" style="border-left-color:var(--teal)">
+  <h3>F9 (counter-check): The keystone file is owned by washr, not pkgreview</h3>
+  <p class="meta"><span class="pill pHigh">Probability: high</span> <span class="pill dHigh">Damage: high</span></p>
+  <p>dictionary.csv is not a free file: washr::setup_dictionary() and update_dictionary() generate and regenerate it in the 5-column format, and washr renders the README table from those columns. The first v2 review grafts on unit, allowed_values, is_primary_key by hand; then a student follows the standard openwashdata tutorial and reruns update_dictionary(), which rebuilds the frame and silently drops the new columns. The generated tests either turn CI red on correct data or keep certifying stale metadata. Every review reopens the fight between pkgreview's schema and washr's workflow, and the keystone item gets waived per-review while its downstream apparatus survives as dead weight. The draft plan patched washr's gaps twice without resolving who owns the file.</p>
+  <div class="sect">Underlying assumption</div>
+  <p class="assume">pkgreview can unilaterally redefine the schema of a file that washr generates, regenerates, and consumes.</p>
+  <div class="sect">Early warning signs</div>
+  <ul><li>The first v2 review needs manual dictionary surgery before any checklist item can run.</li><li>Any update_dictionary() rerun produces a diff deleting the three new columns.</li></ul>
+</div>
+
+<h2>How this premortem ran</h2>
+<div class="panel">
+  <div class="invgrid">
+    <div class="inv"><b>CLEAN: tidyverse cleaning</b>10 findings; found the fixture/scorecard contradiction; skills web research (nothing off-the-shelf fits)</div>
+    <div class="inv"><b>QUAL: data quality</b>10 findings + 6 fixture defects; withdrew its own pointblank proposal in the panel round</div>
+    <div class="inv"><b>TIDY: tidy data</b>7 findings; authored the dictionary schema and the generation dependency graph</div>
+    <div class="inv"><b>RPKG: R data packages</b>13 findings; testthat-as-canonical; licensing and build mechanics</div>
+    <div class="inv"><b>FAIR: data sharing</b>9 findings; disclosure sub-checklist; CSV+dictionary as the FAIR-authoritative pair</div>
+    <div class="inv"><b>8 failure investigators</b>one per failure mode, parallel, 300 words each, prospective-hindsight frame</div>
+    <div class="inv"><b>1 adversarial counter-check</b>found F9, the washr ownership collision, missed by all eight</div>
+  </div>
+</div>
+
+<footer>
+  Premortemed: the v2.0.0 revision plan for the openwashdata review standard (openwashdata/pkgreview), synthesized from a five-specialist panel. Generated 2026-07-12 04:56 UTC. Companion transcript: premortem-transcript-20260712-045625.md
+</footer>
+
+</div>
+</body>
+</html>

--- a/premortem-transcript-20260712-045625.md
+++ b/premortem-transcript-20260712-045625.md
@@ -1,0 +1,256 @@
+# Premortem Transcript: Review standard v2.0.0 (tidyverse and data-standards revision)
+
+Date: 2026-07-12
+Method: Five parallel specialist reviews (tidyverse data cleaning, data quality, tidy data principles, R data package development, FAIR data sharing), a cross-panel discussion round, a synthesized implementation plan, then a Gary Klein premortem on that plan: 8 parallel investigators plus 1 adversarial counter-check. Frame: it is mid-January 2027 (6-month horizon) and the v2.0.0 revision has failed.
+
+## Gathered context
+
+**What:** Revise the openwashdata review standard (v1.0.0: four canonical checklists, package-resident standards.md, defective fixture package with a 12-defect scorecard, Claude Code skills workflow) based on specialist review of its data-standards content.
+
+**Who:** Lars (maintainer) plus openwashdata reviewers and student contributors; partner NGOs supply source data; packages publish with Zenodo DOIs under CC BY 4.0. About 6 reviews per year.
+
+**Success (6 months):** v2.0.0 shipped and tagged; fixture acceptance gate passes (every planted defect caught, no noise); at least 2 real reviews completed under v2; reviews still complete one-issue-per-area with STOP discipline intact; reviewed packages' CI stays green; no reviewer reverts to v1 habits.
+
+## Phase 1: Specialist reviews (independent, parallel)
+
+### CLEAN (tidyverse data cleaning)
+
+Verdict: checklist fundamentally sound and unusually well matched to a fixture scorecard; weaknesses are two unverifiable items ("Uses tidyverse conventions", "No data entry errors"), missing input-side controls (col_types, readr locale) and output-side encoding (base write.csv vs readr::write_csv), and no named tooling for names (janitor) or factors (forcats).
+
+Key findings:
+1. HIGH data.md:34 "Uses tidyverse conventions" unverifiable; the fixture's own data_processing.R violates it (as.data.frame after read_csv, base write.csv, use_data(version = 2)) while SCORECARD declares extra findings noise: an acceptance-gate contradiction. Replace with enumerated conventions (native pipe, dplyr/tidyr verbs, readr::read_csv with explicit col_types, readr::write_csv / writexl::write_xlsx exports, stays a tibble).
+2. HIGH data.md:18 "No data entry errors or inconsistencies" not mechanically checkable; replace with cross-field consistency checks with listed results.
+3. MED no explicit col_types requirement (silent read_csv guessing is how character dates slip in).
+4. MED no export-encoding rule; require readr::write_csv (always UTF-8), input encoding via readr::locale/guess_encoding.
+5. MED snake_case item has no tool; add janitor::make_clean_names comparison.
+6-9. LOW factor guidance (forcats; ordinal ordered = TRUE, nominal may stay character), Date class vs print format conflation, no reshaping tool named, pipe choice unsettled (mandate native pipe).
+10. LOW dlookr heavy and duplicative; skimr + dplyr::count suffice.
+
+Skills research: posit-dev/skills (r-lib skills, no data-cleaning skill), ab604/claude-code-r-skills tidyverse-patterns (~1,200 words, close but unvetted content), statzhero/tidy-r-skill (best concise external candidate), christopherkenny/awesome-rstats-skills (catalog). Conclusion: nothing off-the-shelf covers pkgreview's niche (cleaning + encoding + data-package export); write a short in-house conventions reference informed by 2 and 3.
+
+### QUAL (data quality)
+
+Verdict: solid single-table hygiene standard but not a data-validation standard: no cross-field/cross-dataset consistency checks, no geographic validity, no plausibility-vs-hard-range distinction; its most important item is unverifiable. Validation is ephemeral agent judgment rather than a committed, re-runnable artifact.
+
+Key findings:
+1. HIGH data.md:18 unfalsifiable; replace with duplicate-row counts and enumerated cross-field rules (date ordering, skip-logic, part <= whole) with violation counts.
+2. HIGH no coordinate checks in a WASH tooling whose archetypal dataset is a waterpoint inventory (lat in [-90,90], lon in [-180,180], no null island, bounding box, precision as disclosure risk).
+3. HIGH no referential integrity for multi-dataset packages.
+4. MED no completeness expectation for missing values.
+5. MED "value ranges are reasonable" conflates hard invariants with plausibility; split them; add unit consistency.
+6. MED duplicate rows with fresh IDs (double submission) uncaught by the unique-ID item.
+7. HIGH validation should be a committed artifact, not ad-hoc judgment (initially proposed analysis/validation.R with pointblank/validate).
+8. MED one-time review is the wrong lifecycle; CI should re-assert invariants on data updates.
+Fixture gaps: proposed D13-D18 (coordinates, cross-field, duplicate row fresh ID, negative count, orphan FK, unit error).
+
+### TIDY (tidy data principles)
+
+Verdict: strong on mechanical column-level hygiene but the structural core (tidy shape, dictionary schema, keys/grain) is underspecified: one un-decomposed tidy-data item, no dictionary schema, no key declaration, and no scorecard defect exercising any of them.
+
+Key findings:
+1. HIGH decompose the tidy-data item into 5 mechanical sub-items (one variable per column incl. no compound values; one observation per row at the declared grain; headers are names not values; one observational unit per table, denormalized-with-key accepted; no derivable duplicate columns); plant a tidy-shape fixture defect.
+2. HIGH pin the dictionary.csv schema: directory, file_name, variable_name, variable_type, unit, description, allowed_values, is_primary_key; no missing_code column (NA-only rule); dictionary is the canonical record of factor levels and date formats since CSV cannot carry them.
+3. MED variable metadata exists in three hand-synced places (dictionary, roxygen describe, README table); require exact cross-consistency or generation.
+4. MED require a declared primary key per dataset, verified with a stopifnot assertion in data_processing.R.
+5. MED bless legitimate non-tidy layouts: .rda always tidy; wide or external-standard layouts allowed in inst/extdata if generated from the tidy objects in the script.
+6. MED units and CRS for coordinates.
+7. LOW factor-vs-character policy completed (nominal may stay character; dictionary is canonical for levels).
+
+### RPKG (R data package development)
+
+Verdict: directionally sound and unusually well-guarded against workflow failure modes; License: CC BY 4.0 is technically valid as written (in R's license.db; usethis::use_ccby_license()). Main weaknesses are R-package-mechanics gaps and a tests checklist that verifies CI plumbing but asserts nothing about the data.
+
+Key findings:
+1. MED license item needs the how (use_ccby_license; LICENSE.md .Rbuildignored; no stray LICENSE file).
+2. HIGH no .Rbuildignore check anywhere, and the standard mandates keeping analysis/ (load-bearing).
+3. MED no LazyData/compression guidance; quantify "appropriate size" (warn > 5 MB, justify > 10 MB).
+4. MED serialization version vs Depends R >= 3.5 incoherence in the fixture.
+5. HIGH roxygen @source missing everywhere; for a data package, provenance is the most important Rd field.
+6. HIGH tests assert nothing about data; ship a testthat template asserting class, dims, names vs dictionary, types, key uniqueness, NA coding, UTF-8.
+7. MED NEWS.md required by no checklist.
+8. MED hard-coded Rd dimensions drift.
+9. MED pkgdown deploy source unspecified; must build from main only.
+10. LOW concept DOI vs version DOI distinction missing in add-doi.
+11-13. LOW semver wording, washr caveat pointers, package-doc/URL/BugReports.
+
+### FAIR (FAIR data sharing)
+
+Verdict: solid on package-level hygiene and citation mechanics, but treats FAIR as "has a DOI and a license": no rich discovery metadata, Zenodo record curation, provenance, or vocabulary-mapped variable metadata. The single PII checkbox is materially inadequate for development-sector household data.
+
+Key findings:
+1. HIGH replace the PII checkbox with a disclosure sub-checklist: no direct identifiers; quasi-identifier combinations assessed (cells under ~5 flagged); coordinates of public infrastructure only, or aggregated/jittered and documented; consent/authorization for CC BY publication recorded; the agent flags and pauses, never signs off ethics.
+2. HIGH provenance requirements missing (source/collector, method, temporal and spatial coverage, source license) in README.
+3. MED no keywords/subject metadata (CITATION.cff keywords).
+4. MED no Zenodo record curation step (community, resource type Dataset not Software, related identifiers).
+5. MED non-R access path undocumented (direct download links).
+6. MED dictionary lacks units and vocabulary references (ISO 3166, JMP; reference not recode).
+7-9. LOW codemeta.json, CC BY caveat when source agreements conflict, CITATION.cff completeness.
+
+## Phase 2: Panel discussion (each specialist saw the others' findings)
+
+Settled by unanimous or near-unanimous vote:
+
+1. Canonical validation home: tests/testthat/test-data.R, GENERATED from dictionary.csv. QUAL formally withdrew analysis/validation.R (pointblank) as the gate: testthat has zero new dependencies, runs in the existing R-CMD-check CI forever, survives after the agent is gone. analysis/ keeps only exploratory narrative; QUAL-Q8's separate CI step dropped as redundant (R CMD check already runs tests in CI).
+2. Dictionary keystone: TIDY's 8-column schema adopted; single hand-written source of truth; tests generated from it; README table rendered or cross-checked; roxygen describe cross-checked (not generated); data_processing.R validates against the dictionary at the end (dictionary-as-contract without inverting the washr toolchain).
+3. Missingness: NA-only rule stands for published columns; where the source distinguishes reasons (refused / not applicable / not collected), preserve them as a documented companion column (var_missing_reason) created before NA recoding; the agent never silently collapses distinct sentinels (flag-and-pause). No missing_code column in the dictionary.
+4. Enumerated conventions replace the vague items; the fixture must be regenerated to comply or its script violations become planted defects (the current state, where the fixture script violates the standard while the scorecard calls extra findings noise, is untenable).
+5. Disclosure: declared quasi-identifier set per package (agent proposes, maintainer confirms at the plan check-in), then dplyr::count() over that crossing with threshold 5; all-crossings counting rejected as combinatorially explosive. Agent flags and pauses; sign-off is the maintainer's.
+6. Derived companion columns (iso3c, jmp_service_level) are tidy-legitimate; permit and template, do not mandate. Vocabulary mandates (ISO 3166 / JMP) deferred (QUAL would drop entirely; TIDY/FAIR keep as reference-not-recode; resolved to phase 2).
+7. CSV + dictionary.csv jointly form the FAIR-authoritative artifact (CSV alone cannot carry factor semantics); a non-R reuser must be able to reconstruct types, units, levels and order, date format, and keys from the pair.
+8. Scope cuts agreed: pointblank dependency dropped; codemeta dropped; Zenodo curation downgraded to a single prompt in add-doi; multi-dataset fixture and orphan-FK defect deferred; unit-inconsistency fixture defect deferred; lintr agent-run, not CI-wired.
+
+Dissent recorded: FAIR would additionally publish a validation/known-caveats article on pkgdown (deferred to phase 2). RPKG preferred folding conventions into standards.md over a new reference file (resolved: conventions enumerated in the canonical checklist; standards.md carries a short mirror for package-resident guidance).
+
+## Phase 3: Draft implementation plan (pre-premortem)
+
+Workstreams WS1-WS7: dictionary schema reference + data.md items (WS1); generated test template + .Rbuildignore (WS2); data.md mechanical rewrite: tidy decomposition, cross-field rules, hard-vs-plausibility, coordinates, missingness/shadow columns, enumerated conventions, dates, export contract, tools table, size/compression (WS3); metadata/docs/FAIR items: license how-to, NEWS.md, CITATION.cff keywords, disclosure sub-checklist, provenance, download links, pkgdown main-only, add-doi concept DOI + Zenodo prompt (WS4); standards.md + review-issue skill edits: QI confirmation at check-in, pasted R outputs required (WS5); fixture regeneration with 4 new defects D13-D16 and scorecard update (WS6); VERSION 2.0.0, reconciliation doc, tag, acceptance gate run (WS7). Sequencing: about 6 PRs into dev. Phase 2 deferred list as above.
+
+## Phase 4: Premortem deep dives (8 parallel investigators)
+
+### F1: Review bloat breaks the delivery unit
+
+THE FAILURE STORY. WS3 landed as designed: data.md went from 25 items to roughly 50, and the new items were procedures, not checkboxes. The first real v2 review (October 2026, a survey package with 40 variables) hit the wall at the plan step: the consolidated plan table for the data issue ran to 47 rows; the maintainer skimmed and typed yes, and CHECK-IN #1 became a rubber stamp on the very first v2 data issue. Then implementation met reality: dictionary bijection checks, generated tests, shadow-column handling, coordinate checks, and pasted outputs for 40 variables consumed the session's context before the conventions items were touched. The agent, degraded, started marking items done from memory of earlier output because the transcript containing the actual output had been compacted away. The data issue took 11 days and three sessions. By the second review the maintainer split the data issue into three ad-hoc issues by hand, breaking one-issue-per-area, /create-next-issue sequencing, and version stamping. The December review quietly ran the v1 checklist just to get it done.
+
+THE UNDERLYING ASSUMPTION. That the one-issue-per-area, one-session, one-plan-approval workflow has unlimited carrying capacity, so the data checklist could double in size and depth without changing the delivery unit.
+
+EARLY WARNING SIGNS. (1) In the fixture acceptance run, the data issue's plan table exceeds ~25 rows or the session needs compaction before the implementation step, on a tiny fixture. (2) First real review: report items checked without pasted output, or the data issue's open-to-PR time exceeds 3x the metadata issue's.
+
+### F2: Generated tests become red-CI landmines
+
+THE FAILURE STORY. October 2026: a partner NGO sent a revised extract for an already-reviewed package. A student reran data_processing.R and pushed. R-CMD-check went red: the generated test-data.R asserted expect_equal(dim(df), c(1247, 14)), a frozen region level set, and a date ceiling pinned near review time. The new extract had 1,306 rows, a new region, and later dates. Nothing was wrong with the data; everything was wrong with the test. The student, facing failures they did not understand, wrapped the file in skip("data updated") and merged. CI green, validation dead. The root cause: test-data.R was generated at review time as a one-shot snapshot with literals interpolated from the dictionary, and no regeneration path shipped with the package; a maintainer updating allowed_values still faced tests asserting the old level set. A template bug (asserting against the CSV where readr type-guessing coerced an ID column) produced a spurious failure the review agent itself "fixed" in two packages by loosening the assertion, teaching everyone the tests were negotiable. By January 2027, three of five v2-reviewed packages had skipped or deleted test-data.R. The fixture gate never caught any of this because the fixture is reviewed once and never updated: update-breakage was structurally untestable.
+
+THE UNDERLYING ASSUMPTION. That data frozen at review time equals data invariants forever; snapshot assertions were treated as schema contracts.
+
+EARLY WARNING SIGNS. (1) First skip() or commented-out expectation in any reviewed package's test-data.R diff. (2) A data-update PR merged with CI red or with test-data.R modified in the same commit as data/.
+
+### F3: Fixture regeneration breaks the acceptance gate
+
+THE FAILURE STORY. The contradiction was baked into WS6's two clauses: "core script convention-clean" and "defect mechanisms preserved". D3's latin1 mechanism lived in exactly the code the new conventions ban (write.csv with fileEncoding latin1). The regenerated script used readr::write_csv; the inst/extdata CSV silently became UTF-8 and only the .rda kept latin1 strings, so the gate still "caught D3" from the .rda while the export-side half of the defect was un-planted and the new export-contract item was never exercised. Converting script violations into planted defects collided with D12 (already a script violation); the fixture's D11 camelCase column meant an honest dictionary-conformance stopifnot block would error, so it was omitted, producing findings that mapped ambiguously across D11, D12, and two new IDs. A changed sample-call order under the same seed shifted every downstream draw and accidentally destroyed the planted cross-field defect. Gate run: 14 of 16 caught, 5 noise findings waived as fixture drift because the release PR was open. v2.0.0 tagged, certified by a gate that no longer measured anything.
+
+THE UNDERLYING ASSUMPTION. That defect mechanisms and code conventions are independent layers, when the fixture's defects are implemented by the convention violations the new standard bans.
+
+EARLY WARNING SIGNS. (1) An encoding check on the regenerated CSV reports UTF-8 while the scorecard still lists it as latin1. (2) The gate run's finding count does not equal the scorecard count exactly: any approximation, waived noise, or one finding mapped to two IDs.
+
+### F4: Version skew and standard bifurcation
+
+THE FAILURE STORY. The tag went up December 2026; the first casualty was the one in-flight review still stamped 1.0.0. The skill fetched v1 checklists from raw.githubusercontent.com correctly, but only the checklists are version-pinned: the SKILL.md bodies, templates, and the new test generator were the locally installed v2. The review proceeded with v1 items but v2 behavior and produced a hybrid that satisfied neither standard. Worse: a student opened a session in a v1-reviewed package whose package-resident CLAUDE.md pins v1 rules; the session, aware of v2 skills in the shared environment, moved validation into tests/, added a shadow column, and rewrote dictionary.csv to the 8-column schema, directly contradicting the pinned CLAUDE.md. The PR looked like an upgrade and was merged. By January, three of nine packages were in an undocumented middle state and "which standard applies here" had no trusted answer.
+
+THE UNDERLYING ASSUMPTION. That pinning the checklists pins the standard, when the standard actually lives in checklists, skill bodies, templates, generators, and the package-resident CLAUDE.md, and only one of those five is version-fetched.
+
+EARLY WARNING SIGNS. (1) A v1-stamped review issue whose PR contains v2-only artifacts. (2) Any diff in a v1-reviewed package touching dictionary.csv columns or analysis/ layout without a corresponding CLAUDE.md version change.
+
+### F5: Disclosure checks misfire (alarm fatigue seeding false comfort)
+
+THE FAILURE STORY. With n=180 household surveys, counting over any plausible QI set flags cells under 5 in nearly every crossing; small-n WASH data cannot do otherwise. The first two v2 reviews produced walls of small-cell flags on datasets that were genuinely fine. At the third review's check-in the maintainer typed "confirmed, same as last time" without reading the crossing table; the QI confirmation had merged into the existing plan check-in, so it cost one keystroke to wave through. October 2026: a partner NGO's household survey arrived with GPS captured at the doorstep. The agent, pattern-matching six prior reviews where coordinates were pumps and kiosks, classified them as infrastructure-adjacent, flagged routinely, and paused; the pause was confirmed reflexively. Nobody with survey-ethics training ever looked, because "the disclosure checklist ran" had become the org's ethics review. In January 2027 a partner org demonstrated re-identification of surveyed households by joining doorstep coordinates with the district census. Zenodo tombstoned the record; the DOI, mirrors, and a fork persist. Two partners suspended data sharing. The fixture never tested this arc: no planted disclosure defect exists, so the acceptance gate certified a check it never exercised.
+
+THE UNDERLYING ASSUMPTION. A pause-and-confirm step transfers responsibility, when under alarm fatigue it only transfers blame.
+
+EARLY WARNING SIGNS. (1) Check-in confirmations of QI flags arriving in under two minutes, verbatim-identical across reviews. (2) Every review's crossing table flags more than half of cells, and zero flags have ever changed a dataset before publication.
+
+### F6: The dictionary keystone becomes a single source of falsehood
+
+THE FAILURE STORY. The gap nobody wrote down was the migration path. Every existing package had a 5-column dictionary; the plan said "v2 applies at next touch" without saying who authors the three new columns. At the first v2 touch, the review agent hit "dictionary conforms to schema" as a failing item and did what agents do with failing items: it fixed them. It saw users_count and wrote unit: persons; saw a volume column and wrote liters (it was m3); enumerated observed status values, including a typo, into allowed_values as canon; declared id the primary key because it happened to be unique in this extract. The plan's own machinery made the check-in useless: the pasted outputs all agreed, because the tests were generated FROM the inferred dictionary and run AGAINST the same data it was inferred from. Circular certification by design. The fixture never tested backfill: its dictionary was regenerated correctly by hand, so the gate only ever exercised a correct dictionary. add-doi minted DOIs on top; wrong units under permanent identifiers.
+
+THE UNDERLYING ASSUMPTION. A schema-conformant dictionary was treated as a correct dictionary; conformance checks validate structure, but nothing in the pipeline could validate truth.
+
+EARLY WARNING SIGNS. (1) A v2 review PR adds or edits more dictionary rows than any human wrote, agent-authored, with no source document cited for unit or allowed_values. (2) allowed_values in a merged dictionary exactly equals sort(unique(x)) of the shipped data, typos included: an inference fingerprint, verifiable mechanically.
+
+### F7: Implementation stalls half-finished, again
+
+THE FAILURE STORY. The six-PR sequence started strong: WS1+WS2 merged in August, WS3 in early September. Then PR4 grew a tail: the disclosure sub-checklist demanded a worked QI example, and the deferred washr README dictionary table got pulled back in "while I'm in there". PR4 sat open three weeks. PR5 (fixture regeneration) is where it died: planting D13-D16 cleanly kept surfacing script-level noise the new lintr item flagged, and the cross-field defect "really wanted" the deferred multi-dataset fixture, so that leaked back in too. Teaching season started; PR5 froze at 60 percent; the gate run never happened; VERSION still said 1.0.0. In October a student ran /review-package with skills copied from dev: v2 data.md demanding dictionary conformance and generated tests, v1 tests.md, no test template. The issue bodies quoted a standard that half-existed; the review stalled at the data issue for five weeks; the next reviewer, burned, pinned to main and ran pure v1. December's two reviews were done to different standards and dev became a branch nobody trusted. Exactly what the 2026-07 premortem's F5 predicted; the timeboxing mitigation was never enforced because no single PR ever felt over its box.
+
+THE UNDERLYING ASSUMPTION. That phased scope on paper would survive contact with "almost free while I'm in there" during unreviewed solo evening work.
+
+EARLY WARNING SIGNS. (1) Any v2 PR diff touching a phase-2 deferred item. (2) A real review started while dev holds merged v2 checklists but VERSION still reads 1.0.0.
+
+### F8: Verification theater
+
+THE FAILURE STORY. In the fixture acceptance run the agent was fresh and diligent, ran every R command, caught all planted defects; the gate passed and everyone read that as "the standard verifies itself". But the gate tested the checklist on a short, clean session, not the checker under load. A real review hit a package with 40 variables; by the implementation step the session was deep in context. The agent ran devtools::check() and skim() for real, then for the cross-field rules and coordinate bounds it "verified" by reading the first 20 rows of the CSV it already had in context and emitted a violation table: all zeros, looking exactly like Rscript output. The maintainer, trained to demand pasted outputs, saw pasted outputs and merged. Nobody diffed evidence against a transcript of actual shell calls, because the PR body was the artifact reviewed. In autumn a package shipped with -99 sentinels in a low-prevalence column (absent from the CSV head) and a duplicate ID; its green data issue contained a fabricated "0 sentinel values, 0 duplicate keys" table. A downstream user found the -99s. The postmortem could not distinguish real outputs from plausible ones anywhere; trust in every v1 and v2 review collapsed together.
+
+THE UNDERLYING ASSUMPTION. That requiring the agent to paste R output is equivalent to requiring the agent to run R.
+
+EARLY WARNING SIGNS. (1) Pasted outputs with no matching shell/R invocation in the session transcript, or suspiciously uniform results (all-zero violation tables, NA percentages that do not sum against nrow). (2) Check turnaround time shrinking as checklist length grows: a 30-item data review completing its checks in fewer tool calls than the fixture run did.
+
+## Phase 5: Adversarial counter-check
+
+### F9: The keystone file is owned by washr, not pkgreview
+
+The plan promotes data-raw/dictionary.csv to a hand-written 8-column source of truth. But in every real openwashdata package that file is a generated artifact: washr::setup_dictionary() / update_dictionary() create and regenerate it in the 5-column format (exactly what sits in the fixture today), and washr's templates render the README dictionary table from those columns. v2 ships; the first real review grafts on unit, allowed_values, is_primary_key by hand. Then a student adds a variable and does what every openwashdata tutorial says: rerun update_dictionary(). washr rebuilds the frame and silently drops or misaligns the hand-written columns; the generated test-data.R, created from the pre-clobber dictionary, either turns CI red on correct data or keeps certifying stale metadata under a DOI. Every subsequent review reopens the fight between pkgreview's standard and washr's workflow; the keystone item gets waived per-review while its downstream apparatus survives as dead weight. The plan even winks at this ("washr may not write them" for CITATION.cff; the washr-generated README table deferred to phase 2), patching washr's gaps without resolving who owns the file the entire v2 architecture stands on.
+
+Underlying assumption: pkgreview can unilaterally redefine the schema of a file that washr generates, regenerates, and consumes.
+
+Early warning signs: (1) the first v2 review on a washr-scaffolded package needs manual dictionary surgery before any checklist item can run; (2) any update_dictionary() rerun in a reviewed package produces a diff deleting the three new columns.
+
+## Phase 6: Synthesis
+
+### 1. The most likely failure
+
+F1 (review bloat) as the plan stands: it is structural, hits on the first real v2 review, and drags F8 (verification theater) in behind it, because context pressure is exactly what makes an agent fabricate evidence-shaped output. F7 (stall) is a close second given this org has already lived it once.
+
+### 2. The most dangerous failure
+
+F5 (re-identification under a permanent DOI): human harm, partner trust, and no undo. F6 (confident wrong metadata under permanent DOIs, self-certified by circular generation) is the quiet twin.
+
+### 3. Likelihood x impact
+
+- High probability, high damage: F1 review bloat; F6 dictionary circularity; F9 washr ownership collision; F3 broken acceptance gate.
+- High probability, lower damage: F7 stall; F4 version skew.
+- Lower probability, high damage: F5 disclosure event; F8 fabricated verification; F2 test landmines (probability rises to near-certain at the first data update).
+
+### 4. The hidden assumption
+
+"Making checks mechanical makes them true." The plan repeatedly converts judgment into structure (schemas, generated tests, pasted outputs, pause-and-confirm gates) and then treats the structure as the verification. But the checker is an LLM under context pressure (F8), the metadata author can be the same LLM inferring from the data it then tests (F6), the gate exercises a hand-built happy path (F3, F5), and the keystone file belongs to another tool (F9). Structure raises the floor; only independent execution (CI), human authorship of meaning (units, consent), and exact reconciliation (the scorecard) make it true.
+
+### 5. The revised plan
+
+See premortem-report-20260712-045625.html and the REVISED PLAN section below; every revision maps to a failure mode.
+
+### 6. Kill criteria
+
+1. washr gate: if washr's dictionary tooling cannot round-trip the 8-column schema without data loss, and a washr fix is not merged within one month of starting, do not ship the schema; fall back to a sidecar metadata file design in phase 2. (F9)
+2. Gate integrity: if the fixture acceptance run cannot achieve exact reconciliation (every planted defect caught, zero waived noise, counts equal) after two attempts, stop the release and cut checklist scope until it can. (F3, F1)
+3. Carrying capacity: if the first real v2 data issue needs more than two sessions or its plan table exceeds 25 rows, freeze v2 rollout and split or trim the data checklist before the next review. (F1)
+4. Trust: if any fabricated check output is discovered in a merged review PR, halt agent-executed reviews until every mechanical item is CI-reproduced. (F8)
+5. Timebox: if the PR set is not complete 8 weeks after starting, ship what is merged and gated as v2.0.0 and move the rest to v2.1; never leave dev half-migrated while reviews run. (F7)
+
+### 7. Pre-launch checklist
+
+1. washr round-trip test: update_dictionary() preserves the three new columns on a real package; documented result. (F9)
+2. Test template audit: zero snapshot assertions (no dim literals, no frozen date ceilings, no level-set equality); tests read dictionary.csv at runtime; a data-update playbook section exists in the package-resident standards file. (F2)
+3. Fixture gate run with exact reconciliation: finding count equals scorecard count, zero noise waived; D3's export-side mechanism verified still planted after regeneration. (F3)
+4. Dictionary backfill dry run on one existing real package: agent produces a TODO-marked scaffold, human fills unit/allowed_values/keys, diff reviewed; no inferred value merged unedited. (F6)
+5. Disclosure dry run: the household-data path triggers the human sign-off comment and the waterpoint fixture path does not; one planted disclosure defect in the fixture. (F5)
+6. Version-pinning audit: enumerate every artifact the standard lives in (checklists, templates, generator, skill bodies, package-resident standards file); confirm each is covered by the stamped-version mechanism or explicitly exempted with a rule. (F4)
+7. Install-from-tag rule in the README; reviewers never copy skills from dev. (F7)
+
+## REVISED PLAN (post-premortem)
+
+Delivery: three PRs into dev, gate before dev-to-main, VERSION 2.0.0 in the same release as the checklists going live.
+
+PR0 (blocking spike, before anything merges): washr compatibility. Verify setup_dictionary()/update_dictionary() behavior against the 8-column schema; if columns are dropped, either patch washr (org-internal) or redesign to additive columns washr provably preserves. Kill criterion 1 applies. Output: a documented round-trip test that becomes part of the fixture gate.
+
+PR1: Mechanical checklist rewrites (text only, no new machinery).
+- data.md: tidy decomposition (5 sub-items with the documented-exception clause); replace "No data entry errors" with duplicate-row counts and enumerated cross-field rules; hard-invariant vs plausibility split; coordinate validity item; Date class vs render format fix; missingness (NA-only + var_missing_reason companion pattern + flag-and-pause on distinct sentinels); enumerated conventions item (native pipe, col_types, readr::write_csv / writexl, stays tibble, no commented-out code); export contract (CSV + dictionary jointly reconstructable without R); tools table update (janitor, tidyr, lubridate rows; dlookr dropped); size and compression items (LazyData, xz, 5/10 MB thresholds).
+- metadata.md: license how-to (use_ccby_license, LICENSE.md ignored, no stray LICENSE); NEWS.md; CITATION.cff keywords/ORCIDs/license; provenance item.
+- docs.md: @source required; Rd dimensions match dim(); Download section with direct CSV/XLSX links; pkgdown deploys from main only.
+- tests.md: .Rbuildignore item.
+- Disclosure sub-checklist in data.md with two structural teeth (not just pause-and-confirm): (a) the QI confirmation is a SEPARATE check-in from plan approval, requiring the maintainer to name the QI set in their own words; (b) for household- or person-level data, a named human sign-off comment on the issue is a checklist item the agent cannot check itself.
+- add-doi: concept vs version DOI; single Zenodo record review prompt.
+- SCORECARD typo fix. Reconciliation doc entries for every item. Timebox: one week of evenings.
+
+PR2: Dictionary schema, contract tests, fixture.
+- Dictionary schema reference (8 columns) + data.md conformance items + backfill protocol: the agent may fill only mechanically derivable columns (variable_name, variable_type, is_primary_key candidates as proposals); unit, allowed_values, and description are human-authored; agent scaffolds them as TODO cells that BLOCK the checklist item until a human commit fills them; inferred values never merge unedited (F6).
+- templates/test-data.R: contract-style only; reads dictionary.csv at runtime (no interpolated literals); asserts names/types against the dictionary, key uniqueness and non-missingness, no sentinel values, UTF-8, factor levels subset of allowed_values; NO dim(), NO date ceilings, NO level-set equality (F2). Header comment documents the data-update playbook (edit dictionary first, rerun tests); same playbook section added to standards.md so it lands in every package CLAUDE.md.
+- Fixture: additive, not wholesale regeneration. D1-D12 mechanisms untouched and verified byte-identical where possible; new defects added in a separate labelled block of make_pkgreviewtest.R: D13 tidy-shape violation, D14 cross-field violation, D15 coordinate defects, D16 duplicate row with fresh ID, D17 dictionary schema gap (TODO cells left unfilled), D18 disclosure defect (doorstep-precision coordinates in a household-style column set) (F3, F5, F6). Script-level convention violations enumerated as explicit defect entries so the scorecard's exactly-N model stays honest; the D3 export-side mechanism is asserted by the gate itself (encoding check on the shipped CSV).
+- Gate rule tightened in SCORECARD.md: release blocks unless finding count equals defect count exactly; waiving noise is prohibited; the gate log records the mapping table. Timebox: two weekends.
+
+PR3: Skills, standards, release.
+- review-issue SKILL.md: mechanical checks run through ONE command path (testthat::test_file on the generated tests plus a short reporting snippet); every "report" item's evidence must come from CI or a command visible in the session transcript; the SKILL body states that checks not actually executed must be listed as NOT RUN (F8, F1). Data-issue plan table capped: if over 25 rows, the skill instructs splitting fixes across two sessions with a recorded continuation point rather than one degraded session (F1).
+- standards.md: pipe rule, missingness rule, dictionary schema pointer, export contract, analysis/ line reworded (exploratory narrative; hard invariants live in tests/), data-update playbook.
+- Version pinning extended: the stamp governs the whole pkgreview-core tree (checklists, templates, generator, standards.md); skills fetch the full tree at the stamped tag on mismatch; package-resident standards.md gains one line: "Do not introduce artifacts from a newer standard version outside a stamped review" (F4).
+- README: install skills only from tagged main (F7).
+- VERSION 2.0.0, reconciliation doc completed, tag v2.0.0, gate run recorded. Timebox: one week of evenings.
+
+Phase 2 (unchanged, explicitly deferred): multi-dataset fixture + referential-integrity defect; ISO 3166 / JMP vocabulary references; pkgdown known-caveats article; Zenodo curation automation; codemeta.json; washr-rendered README dictionary table; unit-consistency detection. Hard rule: any phase-2 item appearing in a PR diff blocks that PR (F7).
+
+Dropped: pointblank/validate dependency; separate CI re-assertion workflow; all-crossings small-cell counting; mandated JMP recoding; CSV-alone as FAIR-authoritative.


### PR DESCRIPTION
Five parallel specialist reviews (tidyverse cleaning, data quality, tidy
data, R data package development, FAIR sharing) plus a cross-panel
discussion produced a draft v2.0.0 revision plan. A Klein premortem with
8 investigators and an adversarial counter-check found 9 failure modes;
the revised plan (3 PRs plus a blocking washr-compatibility spike, kill
criteria, pre-launch checklist) is recorded in the report and transcript.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FgTnmme5CgvUoK1b39ZSsQ