### PR TITLE
docs: record enforcement decisions and ruleset plan limitation

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -74,8 +74,15 @@ JSON
 ```
 
 This blocks direct pushes to `main` and requires one approving review on
-the final dev-to-main PR. Apply it at review start (or org-wide via a
-ruleset at https://github.com/organizations/openwashdata/settings/rules).
+the final dev-to-main PR. Apply it at review start.
+
+Note (2026-07-23): the org-wide alternative, a ruleset at
+https://github.com/organizations/openwashdata/settings/rules, was tried
+and is gated to GitHub Team plans; it is not available on the current
+openwashdata plan. Per-repo protection with the command above works on
+the current plan for public repositories. As of the same date, neither
+layer 2 nor layer 3 is deployed by maintainer decision (issue #8);
+enforcement stands on layer 1.
 
 ## Rollout gate
 


### PR DESCRIPTION
## Summary

- Records in docs/guardrails.md that the org-wide ruleset alternative for branch protection is gated to GitHub Team plans and is not available on the current openwashdata plan.
- Documents the maintainer decision from issue #8: neither layer 2 nor layer 3 is deployed; enforcement stands on layer 1 (per-repo branch protection applied at review start).

## Test plan

- [x] The note in docs/guardrails.md matches the decisions recorded in issue #8 (layer 1 only, org ruleset unavailable on current plan)